### PR TITLE
genj/faq-bundle dev-master now requires symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
-        "genj/faq-bundle": "dev-master"
+        "genj/faq-bundle": "~1.0"
     },
 
     "minimum-stability": "dev",


### PR DESCRIPTION
GenjFaqAdminBundle can't be installed with "genj/faq-bundle" version 1.0
